### PR TITLE
#3 Add net core 3.1 for dependency less path

### DIFF
--- a/Dynamic.Json/Dynamic.Json.csproj
+++ b/Dynamic.Json/Dynamic.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,8 +19,8 @@
     <Version>1.4.0</Version>
     <Copyright>Copyright © Maksim Strebkov</Copyright>
   </PropertyGroup>
-  
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'== 'netStandard2.0'">
     <PackageReference Include="System.Text.Json" Version="7.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
By adding net core 3.1 we can have applications which use the library requiring no additional dependencies as the framework provides what is needed.

Closes #3 